### PR TITLE
CORE-25 fix get current user

### DIFF
--- a/app/core/error.py
+++ b/app/core/error.py
@@ -16,6 +16,7 @@ class DomainErrorCode(str, Enum):
     NOT_ENOUGH_PLAYERS = "NOT_ENOUGH_PLAYERS"
     PLAYERS_NOT_READY = "PLAYERS_NOT_READY"
     NOT_HOST = "NOT_HOST"
+    USER_NOT_IN_ROOM = "USER_NOT_IN_ROOM"
 
 
 class MCRDomainError(Exception):

--- a/app/dependencies/repositories.py
+++ b/app/dependencies/repositories.py
@@ -1,7 +1,6 @@
 from fastapi import Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.error import DomainErrorCode, MCRDomainError
 from app.db.session import get_session
 from app.models.room import Room
 from app.repositories.room_repository import RoomRepository
@@ -27,11 +26,4 @@ async def get_room_by_number(
     room_number: int,
     room_repository: RoomRepository = Depends(get_room_repository),
 ) -> Room:
-    room = await room_repository.get_by_room_number(room_number)
-    if not room:
-        raise MCRDomainError(
-            code=DomainErrorCode.ROOM_NOT_FOUND,
-            message=f"Room with number {room_number} not found",
-            details={"room_number": room_number},
-        )
-    return room
+    return await room_repository.filter_one_or_raise(room_number=room_number)

--- a/app/repositories/base_repository.py
+++ b/app/repositories/base_repository.py
@@ -1,17 +1,27 @@
 from abc import ABC
-from typing import Generic, TypeVar, cast
+from typing import Any, Generic, TypeVar, cast
 from uuid import UUID
 
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlmodel import SQLModel, select
+from sqlalchemy.sql.expression import BinaryExpression
+from sqlmodel import SQLModel
+
+from app.core.error import DomainErrorCode, MCRDomainError
 
 T = TypeVar("T", bound=SQLModel)
 
 
 class BaseRepository(Generic[T], ABC):
-    def __init__(self, session: AsyncSession, model_class: type[T]):
+    def __init__(
+        self,
+        session: AsyncSession,
+        model_class: type[T],
+        not_found_error_code: DomainErrorCode,
+    ):
         self.session = session
         self.model_class = model_class
+        self.not_found_error_code = not_found_error_code
 
     async def get_by_uuid(self, uuid: UUID) -> T | None:
         result = await self.session.execute(
@@ -36,3 +46,58 @@ class BaseRepository(Generic[T], ABC):
         if entity:
             await self.session.delete(entity)
             await self.session.flush()
+
+    async def filter(
+        self,
+        *filters: BinaryExpression,
+        offset: int | None = None,
+        limit: int | None = None,
+        **kwargs: Any,
+    ) -> list[T]:
+        query = select(self.model_class)
+
+        for filter_condition in filters:
+            query = query.where(filter_condition)
+
+        for key, value in kwargs.items():
+            if hasattr(self.model_class, key):
+                query = query.where(getattr(self.model_class, key) == value)
+
+        if offset is not None:
+            query = query.offset(offset)
+        if limit is not None:
+            query = query.limit(limit)
+
+        result = await self.session.execute(query)
+        return list(result.scalars().all())
+
+    async def filter_one(self, *filters: BinaryExpression, **kwargs: Any) -> T | None:
+        results = await self.filter(*filters, limit=1, **kwargs)
+        return results[0] if results else None
+
+    async def filter_one_or_raise(self, *filters: BinaryExpression, **kwargs: Any) -> T:
+        result = await self.filter_one(*filters, limit=1, **kwargs)
+        if not result:
+            raise MCRDomainError(
+                code=self.not_found_error_code,
+                message=f"{self.model_class.__name__} not found",
+                details={
+                    "model": self.model_class.__name__,
+                    "filters": str(filters) if filters else None,
+                    "conditions": kwargs,
+                },
+            )
+        return result
+
+    async def count(self, *filters: BinaryExpression, **kwargs: Any) -> int:
+        query = select(func.count()).select_from(self.model_class)
+
+        for filter_condition in filters:
+            query = query.where(filter_condition)
+
+        for key, value in kwargs.items():
+            if hasattr(self.model_class, key):
+                query = query.where(getattr(self.model_class, key) == value)
+
+        result = await self.session.execute(query)
+        return cast(int, result.scalar_one())

--- a/app/repositories/room_repository.py
+++ b/app/repositories/room_repository.py
@@ -3,6 +3,7 @@ from typing import cast
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.error import DomainErrorCode
 from app.models.room import Room
 from app.models.room_user import RoomUser
 from app.repositories.base_repository import BaseRepository
@@ -10,7 +11,7 @@ from app.repositories.base_repository import BaseRepository
 
 class RoomRepository(BaseRepository[Room]):
     def __init__(self, session: AsyncSession):
-        super().__init__(session, Room)
+        super().__init__(session, Room, DomainErrorCode.ROOM_NOT_FOUND)
 
     async def get_by_room_number(self, room_number: int) -> Room | None:
         result = await self.session.execute(

--- a/app/repositories/room_repository.py
+++ b/app/repositories/room_repository.py
@@ -1,5 +1,3 @@
-from typing import cast
-
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -12,18 +10,6 @@ from app.repositories.base_repository import BaseRepository
 class RoomRepository(BaseRepository[Room]):
     def __init__(self, session: AsyncSession):
         super().__init__(session, Room, DomainErrorCode.ROOM_NOT_FOUND)
-
-    async def get_by_room_number(self, room_number: int) -> Room | None:
-        result = await self.session.execute(
-            select(Room).where(Room.room_number == room_number),
-        )
-        return cast(Room | None, result.scalar_one_or_none())
-
-    async def get_available_rooms(self) -> list[Room]:
-        result = await self.session.execute(
-            select(Room).where(Room.is_playing == False),  # noqa: E712
-        )
-        return cast(list[Room], result.scalars().all())
 
     async def _generate_room_number(self) -> int:
         result = await self.session.execute(select(func.max(Room.room_number)))

--- a/app/repositories/room_user_repository.py
+++ b/app/repositories/room_user_repository.py
@@ -4,13 +4,14 @@ from uuid import UUID
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.error import DomainErrorCode
 from app.models.room_user import RoomUser
 from app.repositories.base_repository import BaseRepository
 
 
 class RoomUserRepository(BaseRepository[RoomUser]):
     def __init__(self, session: AsyncSession):
-        super().__init__(session, RoomUser)
+        super().__init__(session, RoomUser, DomainErrorCode.USER_NOT_IN_ROOM)
 
     async def get_by_room(self, room_id: UUID) -> list[RoomUser]:
         result = await self.session.execute(

--- a/app/repositories/room_user_repository.py
+++ b/app/repositories/room_user_repository.py
@@ -1,7 +1,3 @@
-from typing import cast
-from uuid import UUID
-
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.error import DomainErrorCode
@@ -12,9 +8,3 @@ from app.repositories.base_repository import BaseRepository
 class RoomUserRepository(BaseRepository[RoomUser]):
     def __init__(self, session: AsyncSession):
         super().__init__(session, RoomUser, DomainErrorCode.USER_NOT_IN_ROOM)
-
-    async def get_by_user(self, user_id: UUID) -> RoomUser | None:
-        result = await self.session.execute(
-            select(RoomUser).where(RoomUser.user_id == user_id),
-        )
-        return cast(RoomUser | None, result.scalar_one_or_none())

--- a/app/repositories/room_user_repository.py
+++ b/app/repositories/room_user_repository.py
@@ -13,12 +13,6 @@ class RoomUserRepository(BaseRepository[RoomUser]):
     def __init__(self, session: AsyncSession):
         super().__init__(session, RoomUser, DomainErrorCode.USER_NOT_IN_ROOM)
 
-    async def get_by_room(self, room_id: UUID) -> list[RoomUser]:
-        result = await self.session.execute(
-            select(RoomUser).where(RoomUser.room_id == room_id),
-        )
-        return cast(list[RoomUser], result.scalars().all())
-
     async def get_by_user(self, user_id: UUID) -> RoomUser | None:
         result = await self.session.execute(
             select(RoomUser).where(RoomUser.user_id == user_id),

--- a/app/repositories/user_repository.py
+++ b/app/repositories/user_repository.py
@@ -3,13 +3,14 @@ from typing import cast
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.error import DomainErrorCode
 from app.models.user import User
 from app.repositories.base_repository import BaseRepository
 
 
 class UserRepository(BaseRepository[User]):
     def __init__(self, session: AsyncSession):
-        super().__init__(session, User)
+        super().__init__(session, User, DomainErrorCode.USER_NOT_FOUND)
 
     async def get_by_email(self, email: str) -> User | None:
         result = await self.session.execute(

--- a/app/repositories/user_repository.py
+++ b/app/repositories/user_repository.py
@@ -17,9 +17,3 @@ class UserRepository(BaseRepository[User]):
             select(User).where(User.email == email),
         )
         return cast(User | None, result.scalar_one_or_none())
-
-    async def get_by_uid(self, uid: str) -> User | None:
-        result = await self.session.execute(
-            select(User).where(User.uid == uid),
-        )
-        return cast(User | None, result.scalar_one_or_none())

--- a/app/repositories/user_repository.py
+++ b/app/repositories/user_repository.py
@@ -1,6 +1,3 @@
-from typing import cast
-
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.error import DomainErrorCode
@@ -11,9 +8,3 @@ from app.repositories.base_repository import BaseRepository
 class UserRepository(BaseRepository[User]):
     def __init__(self, session: AsyncSession):
         super().__init__(session, User, DomainErrorCode.USER_NOT_FOUND)
-
-    async def get_by_email(self, email: str) -> User | None:
-        result = await self.session.execute(
-            select(User).where(User.email == email),
-        )
-        return cast(User | None, result.scalar_one_or_none())

--- a/app/services/auth/user_service.py
+++ b/app/services/auth/user_service.py
@@ -36,7 +36,7 @@ class UserService:
         )
 
     async def get_or_create_user(self, user_info: dict[str, Any]) -> tuple[User, bool]:
-        existing_user = await self.user_repository.get_by_email(user_info["email"])
+        existing_user = await self.user_repository.filter_one(email=user_info["email"])
 
         if not existing_user:
             new_uid = await self.generate_unique_uid()

--- a/app/services/auth/user_service.py
+++ b/app/services/auth/user_service.py
@@ -23,8 +23,8 @@ class UserService:
         for _ in range(max_attempts):
             uid = validate_uid(str(randint(100000000, 999999999)))
 
-            existing_user = await self.user_repository.get_by_uid(uid)
-            if not existing_user:
+            count = await self.user_repository.count(uid=uid)
+            if count == 0:
                 return uid
 
         raise MCRDomainError(

--- a/app/services/auth/user_service.py
+++ b/app/services/auth/user_service.py
@@ -77,3 +77,6 @@ class UserService:
         updated_user = await self.user_repository.update(user)
         await self.session.commit()
         return updated_user
+
+    async def get_user_by_id(self, user_id: UUID) -> User | None:
+        return await self.user_repository.filter_one(id=user_id)

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -43,7 +43,6 @@ def run_migrations_offline() -> None:
 
 def run_migrations_online() -> None:
     """Run migrations in 'online' mode."""
-    # 비동기 URI에서 동기 URI로 변경
     sync_uri = settings.sync_database_uri
 
     configuration = config.get_section(config.config_ini_section)

--- a/tests/unit/repositories/test_room_repository.py
+++ b/tests/unit/repositories/test_room_repository.py
@@ -1,6 +1,7 @@
 import pytest
 import pytest_asyncio
 
+from app.core.error import DomainErrorCode, MCRDomainError
 from app.models.room import Room
 from app.models.room_user import RoomUser
 from app.models.user import User
@@ -57,9 +58,9 @@ async def test_playing_room(test_db_session, test_host) -> Room:
 
 
 @pytest.mark.asyncio
-async def test_get_by_uuid(test_db_session, test_room):
+async def test_filter_one_room_by_room_number(test_db_session, test_room):
     repo = RoomRepository(test_db_session)
-    result = await repo.get_by_uuid(test_room.id)
+    result = await repo.filter_one_or_raise(room_number=test_room.room_number)
 
     assert result is not None
     assert result.id == test_room.id
@@ -69,78 +70,49 @@ async def test_get_by_uuid(test_db_session, test_room):
 
 
 @pytest.mark.asyncio
-async def test_get_by_room_number(test_db_session, test_room):
+async def test_filter_available_rooms(test_db_session, test_room, test_playing_room):
     repo = RoomRepository(test_db_session)
-    result = await repo.get_by_room_number(test_room.room_number)
-
-    assert result is not None
-    assert result.id == test_room.id
-    assert result.name == test_room.name
-    assert result.room_number == test_room.room_number
-
-
-@pytest.mark.asyncio
-async def test_get_available_rooms(test_db_session, test_room, test_playing_room):
-    repo = RoomRepository(test_db_session)
-    results = await repo.get_available_rooms()
+    results = await repo.filter(is_playing=False)
 
     assert len(results) == 1
     assert results[0].id == test_room.id
     assert not results[0].is_playing
 
+    # 확인
     for room in results:
         assert room.id != test_playing_room.id
+
+
+@pytest.mark.asyncio
+async def test_nonexistent_room_number(test_db_session):
+    repo = RoomRepository(test_db_session)
+
+    with pytest.raises(MCRDomainError) as exc_info:
+        await repo.filter_one_or_raise(room_number=99999)
+
+    assert exc_info.value.code == DomainErrorCode.ROOM_NOT_FOUND
 
 
 @pytest.mark.asyncio
 async def test_create_room(test_db_session, test_host):
     room = Room(
         name="New Room",
-        room_number=789,
         max_users=4,
         is_playing=False,
         host_id=test_host.id,
     )
 
     repo = RoomRepository(test_db_session)
-    created_room = await repo.create(room)
+    created_room = await repo.create_with_room_number(room)
 
     assert created_room.id is not None
     assert created_room.name == room.name
-    assert created_room.room_number == room.room_number
+    assert created_room.room_number is not None
 
-    result = await repo.get_by_room_number(room.room_number)
+    # 생성된 방을 room_number로 조회
+    result = await repo.filter_one_or_raise(room_number=created_room.room_number)
     assert result is not None
     assert result.id == created_room.id
-
-
-@pytest.mark.asyncio
-async def test_update_room(test_db_session, test_room):
-    test_room.name = "Updated Room"
-    test_room.max_users = 3
-
-    repo = RoomRepository(test_db_session)
-    updated_room = await repo.update(test_room)
-
-    assert updated_room.name == "Updated Room"
-    assert updated_room.max_users == 3
-
-    result = await repo.get_by_uuid(test_room.id)
-    assert result is not None
-    assert result.name == "Updated Room"
-    assert result.max_users == 3
-
-
-@pytest.mark.asyncio
-async def test_delete_room(test_db_session, test_room):
-    repo = RoomRepository(test_db_session)
-    await repo.delete(test_room.id)
-
-    result = await repo.get_by_uuid(test_room.id)
-    assert result is None
-
-    result = await repo.get_by_room_number(test_room.room_number)
-    assert result is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/repositories/test_room_repository.py
+++ b/tests/unit/repositories/test_room_repository.py
@@ -109,7 +109,6 @@ async def test_create_room(test_db_session, test_host):
     assert created_room.name == room.name
     assert created_room.room_number is not None
 
-    # 생성된 방을 room_number로 조회
     result = await repo.filter_one_or_raise(room_number=created_room.room_number)
     assert result is not None
     assert result.id == created_room.id

--- a/tests/unit/repositories/test_roomuser_repository.py
+++ b/tests/unit/repositories/test_roomuser_repository.py
@@ -78,15 +78,6 @@ async def test_room_users(test_db_session, test_room, test_users) -> list[RoomUs
 
 
 @pytest.mark.asyncio
-async def test_get_by_room(test_db_session, test_room, test_room_users):
-    repo = RoomUserRepository(test_db_session)
-    result = await repo.get_by_room(test_room.id)
-
-    assert len(result) == 3
-    assert all(ru.room_id == test_room.id for ru in result)
-
-
-@pytest.mark.asyncio
 async def test_get_by_user(test_db_session, test_users, test_room_users):
     repo = RoomUserRepository(test_db_session)
     result = await repo.get_by_user(test_users[0].id)

--- a/tests/unit/repositories/test_roomuser_repository.py
+++ b/tests/unit/repositories/test_roomuser_repository.py
@@ -78,20 +78,6 @@ async def test_room_users(test_db_session, test_room, test_users) -> list[RoomUs
 
 
 @pytest.mark.asyncio
-async def test_get_by_user(test_db_session, test_users, test_room_users):
-    repo = RoomUserRepository(test_db_session)
-    result = await repo.get_by_user(test_users[0].id)
-
-    assert result is not None
-    assert result.user_id == test_users[0].id
-    assert result.is_ready is True
-
-    non_existent_user_id = "00000000-0000-0000-0000-000000000000"
-    non_existent_result = await repo.get_by_user(non_existent_user_id)
-    assert non_existent_result is None
-
-
-@pytest.mark.asyncio
 async def test_create_and_update_room_user(test_db_session, test_room):
     new_user = User(
         uid="987654321",
@@ -120,7 +106,3 @@ async def test_create_and_update_room_user(test_db_session, test_room):
     updated = await repo.update(created)
 
     assert updated.is_ready is True
-
-    check = await repo.get_by_user(new_user.id)
-    assert check is not None
-    assert check.is_ready is True

--- a/tests/unit/repositories/test_user_repository.py
+++ b/tests/unit/repositories/test_user_repository.py
@@ -32,26 +32,6 @@ async def test_get_by_uuid(test_db_session, test_user):
 
 
 @pytest.mark.asyncio
-async def test_get_by_email(test_db_session, test_user):
-    repo = UserRepository(test_db_session)
-    result = await repo.get_by_email(test_user.email)
-
-    assert result is not None
-    assert result.email == test_user.email
-    assert result.nickname == test_user.nickname
-
-
-@pytest.mark.asyncio
-async def test_get_by_uid(test_db_session, test_user):
-    repo = UserRepository(test_db_session)
-    result = await repo.get_by_uid(test_user.uid)
-
-    assert result is not None
-    assert result.uid == test_user.uid
-    assert result.nickname == test_user.nickname
-
-
-@pytest.mark.asyncio
 async def test_create_user(test_db_session):
     user = User(
         uid="987654321",
@@ -66,10 +46,6 @@ async def test_create_user(test_db_session):
     assert created_user.uid == user.uid
     assert created_user.nickname == user.nickname
 
-    result = await repo.get_by_email(user.email)
-    assert result is not None
-    assert result.id == created_user.id
-
 
 @pytest.mark.asyncio
 async def test_update_user(test_db_session, test_user):
@@ -79,10 +55,6 @@ async def test_update_user(test_db_session, test_user):
     updated_user = await repo.update(test_user)
 
     assert updated_user.nickname == "NewName"
-
-    result = await repo.get_by_email(test_user.email)
-    assert result is not None
-    assert result.nickname == "NewName"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/test_google_service.py
+++ b/tests/unit/services/test_google_service.py
@@ -13,18 +13,16 @@ def user_id():
 
 @pytest.mark.asyncio
 async def test_generate_unique_uid(mock_user_service, mocker):
-    # count 메서드 모킹 - 이미 존재하는 UID인 경우 1 반환, 새 UID인 경우 0 반환
     mocker.patch(
         "app.repositories.user_repository.UserRepository.count",
         side_effect=[
             1,
             0,
-        ],  # 첫 번째 호출에서는 1 (이미 존재), 두 번째는 0 (존재하지 않음)
+        ],
     )
 
     generated_uid = await mock_user_service.generate_unique_uid()
 
-    # 실제 UID 값은 랜덤이므로 검증하지 않고 형식만 확인
     assert len(generated_uid) == 9
     assert generated_uid.isdigit()
 
@@ -34,7 +32,7 @@ async def test_get_or_create_user_new(mock_user_service, mocker):
     user_info = {"email": "new@example.com"}
 
     mocker.patch(
-        "app.repositories.user_repository.UserRepository.get_by_email",
+        "app.repositories.user_repository.UserRepository.filter_one",
         return_value=None,
     )
 
@@ -68,7 +66,7 @@ async def test_get_or_create_user_existing(mock_user_service, mocker):
     )
 
     mocker.patch(
-        "app.repositories.user_repository.UserRepository.get_by_email",
+        "app.repositories.user_repository.UserRepository.filter_one",  # 변경된 부분
         return_value=existing_user,
     )
 

--- a/tests/unit/services/test_google_service.py
+++ b/tests/unit/services/test_google_service.py
@@ -66,7 +66,7 @@ async def test_get_or_create_user_existing(mock_user_service, mocker):
     )
 
     mocker.patch(
-        "app.repositories.user_repository.UserRepository.filter_one",  # 변경된 부분
+        "app.repositories.user_repository.UserRepository.filter_one",
         return_value=existing_user,
     )
 

--- a/tests/unit/services/test_google_service.py
+++ b/tests/unit/services/test_google_service.py
@@ -13,21 +13,20 @@ def user_id():
 
 @pytest.mark.asyncio
 async def test_generate_unique_uid(mock_user_service, mocker):
-    existing_uid = "123456789"
-    new_uid = "987654321"
-
+    # count 메서드 모킹 - 이미 존재하는 UID인 경우 1 반환, 새 UID인 경우 0 반환
     mocker.patch(
-        "app.repositories.user_repository.UserRepository.get_by_uid",
-        side_effect=[User(uid=existing_uid, nickname=""), None],
-    )
-
-    mocker.patch(
-        "app.services.auth.user_service.randint",
-        return_value=int(new_uid),
+        "app.repositories.user_repository.UserRepository.count",
+        side_effect=[
+            1,
+            0,
+        ],  # 첫 번째 호출에서는 1 (이미 존재), 두 번째는 0 (존재하지 않음)
     )
 
     generated_uid = await mock_user_service.generate_unique_uid()
-    assert generated_uid == new_uid
+
+    # 실제 UID 값은 랜덤이므로 검증하지 않고 형식만 확인
+    assert len(generated_uid) == 9
+    assert generated_uid.isdigit()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/test_room_service.py
+++ b/tests/unit/services/test_room_service.py
@@ -10,13 +10,9 @@ from app.models.user import User
 from app.services.room_service import RoomService
 
 
-@pytest.fixture
-def room_id():
-    return uuid.uuid4()
-
-
 @pytest_asyncio.fixture
 async def mock_room_service(mocker):
+    """방 서비스 Mock 픽스처"""
     session = mocker.AsyncMock()
     room_repository = mocker.AsyncMock()
     room_user_repository = mocker.AsyncMock()
@@ -29,6 +25,7 @@ async def mock_room_service(mocker):
         user_repository=user_repository,
     )
 
+    # 방 이름 생성 메서드 고정
     mocker.patch.object(
         service,
         "_generate_random_room_name",
@@ -38,451 +35,425 @@ async def mock_room_service(mocker):
     return service
 
 
-@pytest.mark.asyncio
-async def test_create_room_success(mock_room_service, user_id, room_id):
-    host = User(id=user_id, uid="123456789", nickname="HostUser")
-    mock_room_service.user_repository.get_by_uuid.return_value = host
-
-    mock_room_service.room_user_repository.get_by_user.return_value = None
-
-    room = Room(
-        id=room_id,
-        name="엄숙한 패황전",
-        max_users=4,
-        is_playing=False,
-        host_id=user_id,
-    )
-    mock_room_service.room_repository.create_with_room_number.return_value = room
-
-    mock_room_service.room_repository.get_by_uuid.return_value = room
-
-    mock_room_service.room_user_repository.get_by_room.return_value = []
-
-    room_user = RoomUser(room_id=room_id, user_id=user_id, is_ready=False)
-    mock_room_service.room_user_repository.create.return_value = room_user
-
-    created_room = await mock_room_service.create_room(user_id)
-
-    assert created_room.id == room_id
-    assert created_room.name == "엄숙한 패황전"
-    assert created_room.max_users == 4
-    assert created_room.is_playing is False
-    assert created_room.host_id == user_id
-
-    mock_room_service.session.commit.assert_awaited_once()
-
-
-@pytest.mark.asyncio
-async def test_create_room_user_not_found(mock_room_service, user_id):
-    mock_room_service.user_repository.get_by_uuid.return_value = None
-
-    with pytest.raises(MCRDomainError) as exc_info:
-        await mock_room_service.create_room(user_id)
-
-    assert exc_info.value.code == DomainErrorCode.USER_NOT_FOUND
-    assert str(user_id) in exc_info.value.message
-
-
-@pytest.mark.asyncio
-async def test_create_room_user_already_in_room(mock_room_service, user_id):
-    host = User(id=user_id, uid="123456789", nickname="HostUser")
-    existing_room_id = uuid.uuid4()
-    existing_room_user = RoomUser(
-        room_id=existing_room_id,
-        user_id=user_id,
-        is_ready=True,
-    )
-
-    mock_room_service.user_repository.get_by_uuid.return_value = host
-    mock_room_service.room_user_repository.get_by_user.return_value = existing_room_user
-
-    with pytest.raises(MCRDomainError) as exc_info:
-        await mock_room_service.create_room(user_id)
-
-    assert exc_info.value.code == DomainErrorCode.USER_ALREADY_IN_ROOM
-    assert str(user_id) in exc_info.value.message
-    assert str(existing_room_id) in exc_info.value.details["current_room_id"]
-
-
-@pytest.mark.asyncio
-async def test_join_room_success(mock_room_service, user_id, room_id):
-    user = User(id=user_id, uid="123456789", nickname="TestUser")
-    room = Room(
-        id=room_id,
-        name="엄숙한 패황전",
-        max_users=4,
-        is_playing=False,
-        host_id=uuid.uuid4(),
-    )
-    room_user = RoomUser(room_id=room_id, user_id=user_id, is_ready=False)
-
-    mock_room_service.user_repository.get_by_uuid.return_value = user
-    mock_room_service.room_repository.get_by_uuid.return_value = room
-    mock_room_service.room_user_repository.get_by_room.return_value = []
-    mock_room_service.room_user_repository.get_by_user.return_value = None
-    mock_room_service.room_user_repository.create.return_value = room_user
-
-    result = await mock_room_service.join_room(user_id, room_id)
-
-    assert result.room_id == room_id
-    assert result.user_id == user_id
-    assert result.is_ready is False
-
-    mock_room_service.session.commit.assert_awaited_once()
-
-
-@pytest.mark.asyncio
-async def test_join_room_user_not_found(mock_room_service, user_id, room_id):
-    mock_room_service.user_repository.get_by_uuid.return_value = None
-
-    with pytest.raises(MCRDomainError) as exc_info:
-        await mock_room_service.join_room(user_id, room_id)
-
-    assert exc_info.value.code == DomainErrorCode.USER_NOT_FOUND
-    assert str(user_id) in exc_info.value.message
-
-
-@pytest.mark.asyncio
-async def test_join_room_not_found(mock_room_service, user_id, room_id):
-    user = User(id=user_id, uid="123456789", nickname="TestUser")
-
-    mock_room_service.user_repository.get_by_uuid.return_value = user
-    mock_room_service.room_repository.get_by_uuid.return_value = None
-
-    with pytest.raises(MCRDomainError) as exc_info:
-        await mock_room_service.join_room(user_id, room_id)
-
-    assert exc_info.value.code == DomainErrorCode.ROOM_NOT_FOUND
-    assert str(room_id) in exc_info.value.message
-
-
-@pytest.mark.asyncio
-async def test_join_room_is_playing(mock_room_service, user_id, room_id):
-    user = User(id=user_id, uid="123456789", nickname="TestUser")
-    room = Room(
-        id=room_id,
-        name="엄숙한 패황전",
-        max_users=4,
-        is_playing=True,
-        host_id=uuid.uuid4(),
-    )
-
-    mock_room_service.user_repository.get_by_uuid.return_value = user
-    mock_room_service.room_repository.get_by_uuid.return_value = room
-
-    with pytest.raises(MCRDomainError) as exc_info:
-        await mock_room_service.join_room(user_id, room_id)
-
-    assert exc_info.value.code == DomainErrorCode.ROOM_ALREADY_PLAYING
-    assert str(room_id) in exc_info.value.message
-
-
-@pytest.mark.asyncio
-async def test_join_room_is_full(mock_room_service, user_id, room_id):
-    user = User(id=user_id, uid="123456789", nickname="TestUser")
-    room = Room(
-        id=room_id,
-        name="엄숙한 패황전",
-        max_users=4,
-        is_playing=False,
-        host_id=uuid.uuid4(),
-    )
-
-    room_users = [
-        RoomUser(room_id=room_id, user_id=uuid.uuid4()),
-        RoomUser(room_id=room_id, user_id=uuid.uuid4()),
-        RoomUser(room_id=room_id, user_id=uuid.uuid4()),
-        RoomUser(room_id=room_id, user_id=uuid.uuid4()),
-    ]
-
-    mock_room_service.user_repository.get_by_uuid.return_value = user
-    mock_room_service.room_repository.get_by_uuid.return_value = room
-    mock_room_service.room_user_repository.get_by_room.return_value = room_users
-    mock_room_service.room_user_repository.get_by_user.return_value = None
-
-    with pytest.raises(MCRDomainError) as exc_info:
-        await mock_room_service.join_room(user_id, room_id)
-
-    assert exc_info.value.code == DomainErrorCode.ROOM_IS_FULL
-    assert str(room_id) in exc_info.value.message
-    assert exc_info.value.details["max_users"] == 4
-
-
-@pytest.mark.asyncio
-async def test_join_room_already_in_room(mock_room_service, user_id, room_id):
-    user = User(id=user_id, uid="123456789", nickname="TestUser")
-    room = Room(
-        id=room_id,
-        name="엄숙한 패황전",
-        max_users=4,
-        is_playing=False,
-        host_id=uuid.uuid4(),
-    )
-    existing_room_id = uuid.uuid4()
-    existing_room_user = RoomUser(
-        room_id=existing_room_id,
-        user_id=user_id,
-        is_ready=True,
-    )
-
-    mock_room_service.user_repository.get_by_uuid.return_value = user
-    mock_room_service.room_repository.get_by_uuid.return_value = room
-    mock_room_service.room_user_repository.get_by_room.return_value = []
-    mock_room_service.room_user_repository.get_by_user.return_value = existing_room_user
-
-    with pytest.raises(MCRDomainError) as exc_info:
-        await mock_room_service.join_room(user_id, room_id)
-
-    assert exc_info.value.code == DomainErrorCode.USER_ALREADY_IN_ROOM
-    assert str(user_id) in exc_info.value.message
-    assert str(existing_room_id) in exc_info.value.details["current_room_id"]
-
-
-@pytest.mark.asyncio
-async def test_get_available_rooms(mock_room_service, user_id, room_id):
-    user1 = User(id=user_id, uid="123456789", nickname="HostUser")
-    user2 = User(id=uuid.uuid4(), uid="987654321", nickname="GuestUser")
-
-    room = Room(
-        id=room_id,
-        name="Test Room",
-        room_number=123,
-        max_users=4,
-        is_playing=False,
-        host_id=user_id,
-    )
-
-    room_user1 = RoomUser(room_id=room_id, user_id=user_id, is_ready=True)
-    room_user2 = RoomUser(room_id=room_id, user_id=user2.id, is_ready=False)
-
-    mock_room_service.room_repository.get_available_rooms_with_users.return_value = [
-        (room, [room_user1, room_user2])
-    ]
-
-    mock_room_service.user_repository.get_by_uuid.side_effect = lambda id: {
-        user_id: user1,
-        user2.id: user2,
-    }.get(id)
-
-    result = await mock_room_service.get_available_rooms()
-
-    assert len(result) == 1
-    assert result[0].name == "Test Room"
-    assert result[0].room_number == 123
-    assert result[0].max_users == 4
-    assert result[0].current_users == 2
-    assert result[0].host_nickname == "HostUser"
-
-    assert len(result[0].users) == 2
-
-    host_user = next((u for u in result[0].users if u.nickname == "HostUser"), None)
-    assert host_user is not None
-    assert host_user.is_ready is True
-
-    guest_user = next((u for u in result[0].users if u.nickname == "GuestUser"), None)
-    assert guest_user is not None
-    assert guest_user.is_ready is False
-
-
-@pytest.mark.asyncio
-async def test_end_game_success(mock_room_service, user_id, room_id):
-    host_id = user_id
-    another_user_id = uuid.uuid4()
-
-    room = Room(
-        id=room_id,
-        name="테스트 방",
-        max_users=4,
-        is_playing=True,
-        host_id=host_id,
-    )
-
-    room_users = [
-        RoomUser(id=uuid.uuid4(), room_id=room_id, user_id=host_id, is_ready=True),
-        RoomUser(
-            id=uuid.uuid4(), room_id=room_id, user_id=another_user_id, is_ready=True
-        ),
-    ]
-
-    mock_room_service.room_repository.get_by_uuid.return_value = room
-    mock_room_service.room_user_repository.get_by_room.return_value = room_users
-
-    updated_room = Room(
-        id=room_id,
-        name="테스트 방",
-        max_users=4,
-        is_playing=False,
-        host_id=host_id,
-    )
-
-    mock_room_service.room_repository.update.return_value = updated_room
-
-    result = await mock_room_service.end_game(room_id)
-
-    assert result.id == room_id
-    assert result.is_playing is False
-    assert mock_room_service.session.commit.called
-
-    mock_room_service.room_user_repository.update.assert_called()
-
-
-@pytest.mark.asyncio
-async def test_end_game_room_not_found(mock_room_service, room_id):
-    mock_room_service.room_repository.get_by_uuid.return_value = None
-
-    with pytest.raises(MCRDomainError) as exc_info:
-        await mock_room_service.end_game(room_id)
-
-    assert exc_info.value.code == DomainErrorCode.ROOM_NOT_FOUND
-    assert str(room_id) in exc_info.value.message
-
-
-@pytest.mark.asyncio
-async def test_end_game_room_not_playing(mock_room_service, user_id, room_id):
-    room = Room(
-        id=room_id,
-        name="Test Room",
-        max_users=4,
-        is_playing=False,
-        host_id=user_id,
-    )
-
-    mock_room_service.room_repository.get_by_uuid.return_value = room
-
-    with pytest.raises(MCRDomainError) as exc_info:
-        await mock_room_service.end_game(room_id)
-
-    assert exc_info.value.code == DomainErrorCode.ROOM_NOT_PLAYING
-    assert str(room_id) in exc_info.value.message
-
-
-@pytest.mark.asyncio
-async def test_start_game_success(mock_room_service, user_id, room_id, mocker):
-    room = Room(
-        id=room_id,
-        name="테스트 방",
-        max_users=4,
-        is_playing=False,
-        host_id=user_id,
-        room_number=12345,
-    )
-
-    room_users = [
-        RoomUser(id=uuid.uuid4(), room_id=room_id, user_id=uuid.uuid4(), is_ready=True),
-        RoomUser(id=uuid.uuid4(), room_id=room_id, user_id=uuid.uuid4(), is_ready=True),
-        RoomUser(id=uuid.uuid4(), room_id=room_id, user_id=uuid.uuid4(), is_ready=True),
-        RoomUser(id=uuid.uuid4(), room_id=room_id, user_id=user_id, is_ready=True),
-    ]
-
-    mock_room_service.room_repository.get_by_uuid.return_value = room
-    mock_room_service.room_user_repository.get_by_room.return_value = room_users
-
-    updated_room = Room(
-        id=room_id,
-        name="테스트 방",
-        max_users=4,
-        is_playing=True,
-        host_id=user_id,
-        room_number=12345,
-    )
-    mock_room_service.room_repository.update.return_value = updated_room
-
-    mock_client = mocker.AsyncMock()
-    mock_client.__aenter__.return_value = mock_client
-    mock_client.post.return_value = mocker.AsyncMock()
-    mocker.patch("httpx.AsyncClient", return_value=mock_client)
-
-    result = await mock_room_service.start_game(room_id)
-
-    assert result.id == room_id
-    assert result.is_playing is True
-    mock_room_service.session.commit.assert_awaited_once()
-    mock_client.post.assert_awaited_once_with(
-        f"http://game-server/api/games/{room.room_number}/start",
-        timeout=5.0,
-    )
-
-
-@pytest.mark.asyncio
-async def test_start_game_room_not_found(mock_room_service, room_id):
-    mock_room_service.room_repository.get_by_uuid.return_value = None
-
-    with pytest.raises(MCRDomainError) as exc_info:
-        await mock_room_service.start_game(room_id)
-
-    assert exc_info.value.code == DomainErrorCode.ROOM_NOT_FOUND
-    assert str(room_id) in exc_info.value.message
-
-
-@pytest.mark.asyncio
-async def test_start_game_already_playing(mock_room_service, user_id, room_id):
-    room = Room(
-        id=room_id,
-        name="테스트 방",
-        max_users=4,
-        is_playing=True,
-        host_id=user_id,
-    )
-
-    mock_room_service.room_repository.get_by_uuid.return_value = room
-
-    with pytest.raises(MCRDomainError) as exc_info:
-        await mock_room_service.start_game(room_id)
-
-    assert exc_info.value.code == DomainErrorCode.ROOM_ALREADY_PLAYING
-    assert str(room_id) in exc_info.value.message
-
-
-@pytest.mark.asyncio
-async def test_start_game_not_enough_players(mock_room_service, user_id, room_id):
-    room = Room(
-        id=room_id,
-        name="테스트 방",
-        max_users=4,
-        is_playing=False,
-        host_id=user_id,
-    )
-
-    room_users = [
-        RoomUser(id=uuid.uuid4(), room_id=room_id, user_id=uuid.uuid4(), is_ready=True),
-        RoomUser(id=uuid.uuid4(), room_id=room_id, user_id=uuid.uuid4(), is_ready=True),
-        RoomUser(id=uuid.uuid4(), room_id=room_id, user_id=user_id, is_ready=True),
-    ]
-
-    mock_room_service.room_repository.get_by_uuid.return_value = room
-    mock_room_service.room_user_repository.get_by_room.return_value = room_users
-
-    with pytest.raises(MCRDomainError) as exc_info:
-        await mock_room_service.start_game(room_id)
-
-    assert exc_info.value.code == DomainErrorCode.NOT_ENOUGH_PLAYERS
-    assert str(room_id) in exc_info.value.message
-    assert exc_info.value.details["current_players"] == 3
-
-
-@pytest.mark.asyncio
-async def test_start_game_players_not_ready(mock_room_service, user_id, room_id):
-    room = Room(
-        id=room_id,
-        name="테스트 방",
-        max_users=4,
-        is_playing=False,
-        host_id=user_id,
-    )
-
-    room_users = [
-        RoomUser(id=uuid.uuid4(), room_id=room_id, user_id=uuid.uuid4(), is_ready=True),
-        RoomUser(id=uuid.uuid4(), room_id=room_id, user_id=uuid.uuid4(), is_ready=True),
-        RoomUser(id=uuid.uuid4(), room_id=room_id, user_id=uuid.uuid4(), is_ready=True),
-        RoomUser(id=uuid.uuid4(), room_id=room_id, user_id=user_id, is_ready=False),
-    ]
-
-    mock_room_service.room_repository.get_by_uuid.return_value = room
-    mock_room_service.room_user_repository.get_by_room.return_value = room_users
-
-    with pytest.raises(MCRDomainError) as exc_info:
-        await mock_room_service.start_game(room_id)
-
-    assert exc_info.value.code == DomainErrorCode.PLAYERS_NOT_READY
-    assert str(room_id) in exc_info.value.message
-    assert exc_info.value.details["not_ready_count"] == 1
+class TestRoomServiceCreateRoom:
+    @pytest.mark.asyncio
+    async def test_create_room_success(self, mock_room_service, user_id, room_id):
+        host = User(id=user_id, uid="123456789", nickname="HostUser")
+        mock_room_service.user_repository.filter_one_or_raise.return_value = host
+        mock_room_service.room_user_repository.filter_one.return_value = None
+
+        room = Room(
+            id=room_id,
+            name="엄숙한 패황전",
+            max_users=4,
+            is_playing=False,
+            host_id=user_id,
+        )
+        mock_room_service.room_repository.create_with_room_number.return_value = room
+        mock_room_service.room_repository.filter_one_or_raise.return_value = room
+        mock_room_service.room_user_repository.filter.return_value = []
+
+        room_user = RoomUser(room_id=room_id, user_id=user_id, is_ready=False)
+        mock_room_service.room_user_repository.create.return_value = room_user
+
+        created_room = await mock_room_service.create_room(user_id)
+
+        assert created_room.id == room_id
+        assert created_room.name == "엄숙한 패황전"
+        assert created_room.max_users == 4
+        assert created_room.is_playing is False
+        assert created_room.host_id == user_id
+        mock_room_service.session.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_create_room_user_not_found(self, mock_room_service, user_id):
+        mock_room_service.user_repository.filter_one_or_raise.side_effect = (
+            MCRDomainError(
+                code=DomainErrorCode.USER_NOT_FOUND,
+                message=f"User with ID {user_id} not found",
+                details={"user_id": str(user_id)},
+            )
+        )
+
+        with pytest.raises(MCRDomainError) as exc_info:
+            await mock_room_service.create_room(user_id)
+
+        assert exc_info.value.code == DomainErrorCode.USER_NOT_FOUND
+        assert str(user_id) in exc_info.value.message
+
+    @pytest.mark.asyncio
+    async def test_create_room_user_already_in_room(self, mock_room_service, user_id):
+        host = User(id=user_id, uid="123456789", nickname="HostUser")
+        existing_room_id = uuid.uuid4()
+        existing_room_user = RoomUser(
+            room_id=existing_room_id,
+            user_id=user_id,
+            is_ready=True,
+        )
+
+        mock_room_service.user_repository.filter_one_or_raise.return_value = host
+        mock_room_service.room_user_repository.filter_one.return_value = (
+            existing_room_user
+        )
+
+        with pytest.raises(MCRDomainError) as exc_info:
+            await mock_room_service.create_room(user_id)
+
+        assert exc_info.value.code == DomainErrorCode.USER_ALREADY_IN_ROOM
+        assert str(user_id) in exc_info.value.message
+        assert str(existing_room_id) in exc_info.value.details["current_room_id"]
+
+
+class TestRoomServiceJoinRoom:
+    @pytest.mark.asyncio
+    async def test_join_room_success(self, mock_room_service, user_id, room_id):
+        user = User(id=user_id, uid="123456789", nickname="TestUser")
+        room = Room(
+            id=room_id,
+            name="엄숙한 패황전",
+            max_users=4,
+            is_playing=False,
+            host_id=uuid.uuid4(),
+        )
+        room_user = RoomUser(room_id=room_id, user_id=user_id, is_ready=False)
+
+        mock_room_service.user_repository.filter_one_or_raise.return_value = user
+        mock_room_service.room_repository.filter_one_or_raise.return_value = room
+        mock_room_service.room_user_repository.filter.return_value = []
+        mock_room_service.room_user_repository.filter_one.return_value = None
+        mock_room_service.room_user_repository.create.return_value = room_user
+
+        result = await mock_room_service.join_room(user_id, room_id)
+
+        assert result.room_id == room_id
+        assert result.user_id == user_id
+        assert result.is_ready is False
+        mock_room_service.session.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_join_room_is_playing(self, mock_room_service, user_id, room_id):
+        user = User(id=user_id, uid="123456789", nickname="TestUser")
+        room = Room(
+            id=room_id,
+            name="엄숙한 패황전",
+            max_users=4,
+            is_playing=True,
+            host_id=uuid.uuid4(),
+        )
+
+        mock_room_service.user_repository.filter_one_or_raise.return_value = user
+        mock_room_service.room_repository.filter_one_or_raise.return_value = room
+
+        with pytest.raises(MCRDomainError) as exc_info:
+            await mock_room_service.join_room(user_id, room_id)
+
+        assert exc_info.value.code == DomainErrorCode.ROOM_ALREADY_PLAYING
+        assert str(room_id) in exc_info.value.message
+
+    @pytest.mark.asyncio
+    async def test_join_room_is_full(self, mock_room_service, user_id, room_id):
+        user = User(id=user_id, uid="123456789", nickname="TestUser")
+        room = Room(
+            id=room_id,
+            name="엄숙한 패황전",
+            max_users=4,
+            is_playing=False,
+            host_id=uuid.uuid4(),
+        )
+
+        room_users = [RoomUser(room_id=room_id, user_id=uuid.uuid4()) for _ in range(4)]
+
+        mock_room_service.user_repository.filter_one_or_raise.return_value = user
+        mock_room_service.room_repository.filter_one_or_raise.return_value = room
+        mock_room_service.room_user_repository.filter.return_value = room_users
+        mock_room_service.room_user_repository.filter_one.return_value = None
+
+        with pytest.raises(MCRDomainError) as exc_info:
+            await mock_room_service.join_room(user_id, room_id)
+
+        assert exc_info.value.code == DomainErrorCode.ROOM_IS_FULL
+        assert str(room_id) in exc_info.value.message
+        assert exc_info.value.details["max_users"] == 4
+
+
+class TestRoomServiceGameManagement:
+    @pytest.mark.asyncio
+    async def test_get_available_rooms(self, mock_room_service, user_id, room_id):
+        user1 = User(id=user_id, uid="123456789", nickname="HostUser")
+        user2 = User(id=uuid.uuid4(), uid="987654321", nickname="GuestUser")
+
+        room = Room(
+            id=room_id,
+            name="Test Room",
+            room_number=123,
+            max_users=4,
+            is_playing=False,
+            host_id=user_id,
+        )
+
+        room_user1 = RoomUser(room_id=room_id, user_id=user_id, is_ready=True)
+        room_user2 = RoomUser(room_id=room_id, user_id=user2.id, is_ready=False)
+
+        mock_room_repo = mock_room_service.room_repository
+        mock_room_repo.get_available_rooms_with_users.return_value = [
+            (room, [room_user1, room_user2])
+        ]
+
+        mock_room_service.user_repository.filter_one_or_raise.side_effect = (
+            lambda id=None, **kwargs: {
+                user_id: user1,
+                user2.id: user2,
+            }.get(id or kwargs.get("id"))
+        )
+
+        result = await mock_room_service.get_available_rooms()
+
+        assert len(result) == 1
+        assert result[0].name == "Test Room"
+        assert result[0].room_number == 123
+        assert result[0].max_users == 4
+        assert result[0].current_users == 2
+        assert result[0].host_nickname == "HostUser"
+
+        assert len(result[0].users) == 2
+
+        host_user = next((u for u in result[0].users if u.nickname == "HostUser"), None)
+        assert host_user is not None
+        assert host_user.is_ready is True
+
+        guest_user = next(
+            (u for u in result[0].users if u.nickname == "GuestUser"), None
+        )
+        assert guest_user is not None
+        assert guest_user.is_ready is False
+
+    @pytest.mark.asyncio
+    async def test_end_game_success(self, mock_room_service, user_id, room_id):
+        host_id = user_id
+        another_user_id = uuid.uuid4()
+
+        room = Room(
+            id=room_id,
+            name="테스트 방",
+            max_users=4,
+            is_playing=True,
+            host_id=host_id,
+        )
+
+        room_users = [
+            RoomUser(id=uuid.uuid4(), room_id=room_id, user_id=host_id, is_ready=True),
+            RoomUser(
+                id=uuid.uuid4(), room_id=room_id, user_id=another_user_id, is_ready=True
+            ),
+        ]
+
+        mock_room_service.room_repository.filter_one_or_raise.return_value = room
+        mock_room_service.room_user_repository.filter.return_value = room_users
+
+        updated_room = Room(
+            id=room_id,
+            name="테스트 방",
+            max_users=4,
+            is_playing=False,
+            host_id=host_id,
+        )
+
+        mock_room_service.room_repository.update.return_value = updated_room
+
+        result = await mock_room_service.end_game(room_id)
+
+        assert result.id == room_id
+        assert result.is_playing is False
+        mock_room_service.session.commit.assert_awaited_once()
+        mock_room_service.room_user_repository.update.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_end_game_room_not_found(self, mock_room_service, room_id):
+        mock_room_service.room_repository.filter_one_or_raise.side_effect = (
+            MCRDomainError(
+                code=DomainErrorCode.ROOM_NOT_FOUND,
+                message=f"Room with ID {room_id} not found",
+                details={"room_id": str(room_id)},
+            )
+        )
+
+        with pytest.raises(MCRDomainError) as exc_info:
+            await mock_room_service.end_game(room_id)
+
+        assert exc_info.value.code == DomainErrorCode.ROOM_NOT_FOUND
+        assert str(room_id) in exc_info.value.message
+
+    @pytest.mark.asyncio
+    async def test_end_game_room_not_playing(self, mock_room_service, user_id, room_id):
+        room = Room(
+            id=room_id,
+            name="Test Room",
+            max_users=4,
+            is_playing=False,
+            host_id=user_id,
+        )
+
+        mock_room_service.room_repository.filter_one_or_raise.return_value = room
+
+        with pytest.raises(MCRDomainError) as exc_info:
+            await mock_room_service.end_game(room_id)
+
+        assert exc_info.value.code == DomainErrorCode.ROOM_NOT_PLAYING
+        assert str(room_id) in exc_info.value.message
+
+    @pytest.mark.asyncio
+    async def test_start_game_success(
+        self, mock_room_service, user_id, room_id, mocker
+    ):
+        room = Room(
+            id=room_id,
+            name="테스트 방",
+            max_users=4,
+            is_playing=False,
+            host_id=user_id,
+            room_number=12345,
+        )
+
+        room_users = [
+            RoomUser(
+                id=uuid.uuid4(), room_id=room_id, user_id=uuid.uuid4(), is_ready=True
+            ),
+            RoomUser(
+                id=uuid.uuid4(), room_id=room_id, user_id=uuid.uuid4(), is_ready=True
+            ),
+            RoomUser(
+                id=uuid.uuid4(), room_id=room_id, user_id=uuid.uuid4(), is_ready=True
+            ),
+            RoomUser(id=uuid.uuid4(), room_id=room_id, user_id=user_id, is_ready=True),
+        ]
+
+        mock_room_service.room_repository.filter_one_or_raise.return_value = room
+        mock_room_service.room_user_repository.filter.return_value = room_users
+
+        updated_room = Room(
+            id=room_id,
+            name="테스트 방",
+            max_users=4,
+            is_playing=True,
+            host_id=user_id,
+            room_number=12345,
+        )
+        mock_room_service.room_repository.update.return_value = updated_room
+
+        mock_client = mocker.AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.post.return_value = mocker.AsyncMock()
+        mocker.patch("httpx.AsyncClient", return_value=mock_client)
+
+        result = await mock_room_service.start_game(room_id)
+
+        assert result.id == room_id
+        assert result.is_playing is True
+        mock_room_service.session.commit.assert_awaited_once()
+        mock_client.post.assert_awaited_once_with(
+            f"http://game-server/api/games/{room.room_number}/start",
+            timeout=5.0,
+        )
+
+    @pytest.mark.asyncio
+    async def test_start_game_room_not_found(self, mock_room_service, room_id):
+        mock_room_service.room_repository.filter_one_or_raise.side_effect = (
+            MCRDomainError(
+                code=DomainErrorCode.ROOM_NOT_FOUND,
+                message=f"Room with ID {room_id} not found",
+                details={"room_id": str(room_id)},
+            )
+        )
+
+        with pytest.raises(MCRDomainError) as exc_info:
+            await mock_room_service.start_game(room_id)
+
+        assert exc_info.value.code == DomainErrorCode.ROOM_NOT_FOUND
+        assert str(room_id) in exc_info.value.message
+
+    @pytest.mark.asyncio
+    async def test_start_game_already_playing(
+        self, mock_room_service, user_id, room_id
+    ):
+        room = Room(
+            id=room_id,
+            name="테스트 방",
+            max_users=4,
+            is_playing=True,
+            host_id=user_id,
+        )
+
+        mock_room_service.room_repository.filter_one_or_raise.return_value = room
+
+        with pytest.raises(MCRDomainError) as exc_info:
+            await mock_room_service.start_game(room_id)
+
+        assert exc_info.value.code == DomainErrorCode.ROOM_ALREADY_PLAYING
+        assert str(room_id) in exc_info.value.message
+
+    @pytest.mark.asyncio
+    async def test_start_game_not_enough_players(
+        self, mock_room_service, user_id, room_id
+    ):
+        room = Room(
+            id=room_id,
+            name="테스트 방",
+            max_users=4,
+            is_playing=False,
+            host_id=user_id,
+        )
+
+        room_users = [
+            RoomUser(
+                id=uuid.uuid4(), room_id=room_id, user_id=uuid.uuid4(), is_ready=True
+            ),
+            RoomUser(
+                id=uuid.uuid4(), room_id=room_id, user_id=uuid.uuid4(), is_ready=True
+            ),
+            RoomUser(id=uuid.uuid4(), room_id=room_id, user_id=user_id, is_ready=True),
+        ]
+
+        mock_room_service.room_repository.filter_one_or_raise.return_value = room
+        mock_room_service.room_user_repository.filter.return_value = room_users
+
+        with pytest.raises(MCRDomainError) as exc_info:
+            await mock_room_service.start_game(room_id)
+
+        assert exc_info.value.code == DomainErrorCode.NOT_ENOUGH_PLAYERS
+        assert str(room_id) in exc_info.value.message
+        assert exc_info.value.details["current_players"] == 3
+
+    @pytest.mark.asyncio
+    async def test_start_game_players_not_ready(
+        self, mock_room_service, user_id, room_id
+    ):
+        room = Room(
+            id=room_id,
+            name="테스트 방",
+            max_users=4,
+            is_playing=False,
+            host_id=user_id,
+        )
+
+        room_users = [
+            RoomUser(
+                id=uuid.uuid4(), room_id=room_id, user_id=uuid.uuid4(), is_ready=True
+            ),
+            RoomUser(
+                id=uuid.uuid4(), room_id=room_id, user_id=uuid.uuid4(), is_ready=True
+            ),
+            RoomUser(
+                id=uuid.uuid4(), room_id=room_id, user_id=uuid.uuid4(), is_ready=True
+            ),
+            RoomUser(id=uuid.uuid4(), room_id=room_id, user_id=user_id, is_ready=False),
+        ]
+
+        mock_room_service.room_repository.filter_one_or_raise.return_value = room
+        mock_room_service.room_user_repository.filter.return_value = room_users
+
+        with pytest.raises(MCRDomainError) as exc_info:
+            await mock_room_service.start_game(room_id)
+
+        assert exc_info.value.code == DomainErrorCode.PLAYERS_NOT_READY
+        assert str(room_id) in exc_info.value.message
+        assert exc_info.value.details["not_ready_count"] == 1

--- a/tests/unit/services/test_room_service.py
+++ b/tests/unit/services/test_room_service.py
@@ -25,7 +25,6 @@ async def mock_room_service(mocker):
         user_repository=user_repository,
     )
 
-    # 방 이름 생성 메서드 고정
     mocker.patch.object(
         service,
         "_generate_random_room_name",

--- a/tests/unit/services/test_user_service.py
+++ b/tests/unit/services/test_user_service.py
@@ -6,25 +6,22 @@ from app.models.user import User
 
 @pytest.mark.asyncio
 async def test_generate_unique_uid(mock_user_service, mocker):
-    # count 메서드 모킹 - 이미 존재하는 UID인 경우 1 반환, 새 UID인 경우 0 반환
     mocker.patch(
         "app.repositories.user_repository.UserRepository.count",
         side_effect=[
             1,
             0,
-        ],  # 첫 번째 호출에서는 1 (이미 존재), 두 번째는 0 (존재하지 않음)
+        ],
     )
 
     generated_uid = await mock_user_service.generate_unique_uid()
 
-    # 실제 UID 값은 랜덤이므로 검증하지 않고 형식만 확인
     assert len(generated_uid) == 9
     assert generated_uid.isdigit()
 
 
 @pytest.mark.asyncio
 async def test_generate_unique_uid_failure(mock_user_service, mocker):
-    # count 메서드가 항상 1을 반환하도록 모킹 (항상 UID가 이미 존재)
     mocker.patch(
         "app.repositories.user_repository.UserRepository.count",
         return_value=1,
@@ -41,7 +38,7 @@ async def test_get_or_create_user_new(mock_user_service, mocker):
     user_info = {"email": "new@example.com"}
 
     mocker.patch(
-        "app.repositories.user_repository.UserRepository.get_by_email",
+        "app.repositories.user_repository.UserRepository.filter_one",  # 변경된 부분
         return_value=None,
     )
 
@@ -75,7 +72,7 @@ async def test_get_or_create_user_existing(mock_user_service, mocker):
     )
 
     mocker.patch(
-        "app.repositories.user_repository.UserRepository.get_by_email",
+        "app.repositories.user_repository.UserRepository.filter_one",  # 변경된 부분
         return_value=existing_user,
     )
 
@@ -97,7 +94,7 @@ async def test_get_or_create_user_existing_empty_nickname(mock_user_service, moc
     )
 
     mocker.patch(
-        "app.repositories.user_repository.UserRepository.get_by_email",
+        "app.repositories.user_repository.UserRepository.filter_one",  # 변경된 부분
         return_value=existing_user,
     )
 

--- a/tests/unit/services/test_user_service.py
+++ b/tests/unit/services/test_user_service.py
@@ -167,10 +167,8 @@ async def test_get_user_by_id(mock_user_service, user_id, mocker):
         return_value=user,
     )
 
-    # 테스트 대상 함수 호출
     result = await mock_user_service.get_user_by_id(user_id)
 
-    # 검증
     assert result is not None
     assert result.id == user_id
     assert result.uid == "123456789"

--- a/tests/unit/services/test_user_service.py
+++ b/tests/unit/services/test_user_service.py
@@ -38,7 +38,7 @@ async def test_get_or_create_user_new(mock_user_service, mocker):
     user_info = {"email": "new@example.com"}
 
     mocker.patch(
-        "app.repositories.user_repository.UserRepository.filter_one",  # 변경된 부분
+        "app.repositories.user_repository.UserRepository.filter_one",
         return_value=None,
     )
 
@@ -72,7 +72,7 @@ async def test_get_or_create_user_existing(mock_user_service, mocker):
     )
 
     mocker.patch(
-        "app.repositories.user_repository.UserRepository.filter_one",  # 변경된 부분
+        "app.repositories.user_repository.UserRepository.filter_one",
         return_value=existing_user,
     )
 
@@ -94,7 +94,7 @@ async def test_get_or_create_user_existing_empty_nickname(mock_user_service, moc
     )
 
     mocker.patch(
-        "app.repositories.user_repository.UserRepository.filter_one",  # 변경된 부분
+        "app.repositories.user_repository.UserRepository.filter_one",
         return_value=existing_user,
     )
 

--- a/tests/unit/services/test_user_service.py
+++ b/tests/unit/services/test_user_service.py
@@ -154,3 +154,26 @@ async def test_update_nickname_already_set(mock_user_service, user_id, mocker):
 
     assert exc_info.value.code == DomainErrorCode.NICKNAME_ALREADY_SET
     assert user.nickname in exc_info.value.details["current_nickname"]
+
+
+@pytest.mark.asyncio
+async def test_get_user_by_id(mock_user_service, user_id, mocker):
+    user = User(
+        id=user_id, uid="123456789", nickname="TestUser", email="test@example.com"
+    )
+
+    mocker.patch(
+        "app.repositories.user_repository.UserRepository.filter_one",
+        return_value=user,
+    )
+
+    # 테스트 대상 함수 호출
+    result = await mock_user_service.get_user_by_id(user_id)
+
+    # 검증
+    assert result is not None
+    assert result.id == user_id
+    assert result.uid == "123456789"
+    assert result.nickname == "TestUser"
+
+    mock_user_service.user_repository.filter_one.assert_called_once_with(id=user_id)

--- a/tests/unit/services/test_user_service.py
+++ b/tests/unit/services/test_user_service.py
@@ -6,34 +6,28 @@ from app.models.user import User
 
 @pytest.mark.asyncio
 async def test_generate_unique_uid(mock_user_service, mocker):
-    existing_uid = "123456789"
-    new_uid = "987654321"
-
+    # count 메서드 모킹 - 이미 존재하는 UID인 경우 1 반환, 새 UID인 경우 0 반환
     mocker.patch(
-        "app.repositories.user_repository.UserRepository.get_by_uid",
-        side_effect=[User(uid=existing_uid, nickname=""), None],
-    )
-
-    mocker.patch(
-        "app.services.auth.user_service.randint",
-        return_value=int(new_uid),
+        "app.repositories.user_repository.UserRepository.count",
+        side_effect=[
+            1,
+            0,
+        ],  # 첫 번째 호출에서는 1 (이미 존재), 두 번째는 0 (존재하지 않음)
     )
 
     generated_uid = await mock_user_service.generate_unique_uid()
-    assert generated_uid == new_uid
+
+    # 실제 UID 값은 랜덤이므로 검증하지 않고 형식만 확인
+    assert len(generated_uid) == 9
+    assert generated_uid.isdigit()
 
 
 @pytest.mark.asyncio
 async def test_generate_unique_uid_failure(mock_user_service, mocker):
+    # count 메서드가 항상 1을 반환하도록 모킹 (항상 UID가 이미 존재)
     mocker.patch(
-        "app.services.auth.user_service.randint",
-        return_value=123456789,
-    )
-
-    existing_user = User(uid="123456789", nickname="ExName")
-    mocker.patch(
-        "app.repositories.user_repository.UserRepository.get_by_uid",
-        return_value=existing_user,
+        "app.repositories.user_repository.UserRepository.count",
+        return_value=1,
     )
 
     with pytest.raises(MCRDomainError) as exc_info:


### PR DESCRIPTION
[![CORE-25](https://badgen.net/badge/JIRA/CORE-25/0052CC)](https://mcrs.atlassian.net/browse/CORE-25) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=MCRMasters&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

get current user 함수가 직접 쿼리 호출하는게 아닌 service layer함수를 호출하도록 수정하였습니다.

https://github.com/MCRMasters/MCR-Masters-Core/pull/64
에서 땄습니다.

변경사항은 [여기](https://github.com/MCRMasters/MCR-Masters-Core/pull/65/files/ad07fd11bdf2cff96938f3dc1be9c1e002539cbe..54fa35f62e803cce5967647789f23dca8b257f48)

[CORE-25]: https://mcrs.atlassian.net/browse/CORE-25?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ