### PR TITLE
CORE-39 change websocket to use query parameter

### DIFF
--- a/app/api/v1/endpoints/ws_room.py
+++ b/app/api/v1/endpoints/ws_room.py
@@ -39,7 +39,7 @@ class RoomWebSocketHandler:
     async def handle_connection(self):
         result = True
         try:
-            token = self.websocket.headers.get("authorization")
+            token = self.websocket.query_params.get("authorization")
             if not token:
                 await self.websocket.close(code=status.WS_1008_POLICY_VIOLATION)
                 result = False

--- a/app/services/room_service.py
+++ b/app/services/room_service.py
@@ -246,6 +246,7 @@ class RoomService:
     async def get_room_users(self, room_id: UUID) -> RoomUsersResponse:
         room: Room = await self.room_repository.filter_one_or_raise(id=room_id)
         room_users = await self.room_user_repository.filter(room_id=room_id)
+        host_user = await self.user_repository.filter_one_or_raise(id=room.host_id)
 
         users = [
             RoomUserResponse(
@@ -258,7 +259,7 @@ class RoomService:
         ]
 
         return RoomUsersResponse(
-            host_uid=str(room.host_id),
+            host_uid=host_user.uid,
             users=users,
         )
 


### PR DESCRIPTION
[![CORE-39](https://badgen.net/badge/JIRA/CORE-39/0052CC)](https://mcrs.atlassian.net/browse/CORE-39) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=MCRMasters&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

유니티 WebGL에서 헤더를 사용할 수 없어서 websocket 부분에서 query parameter를 사용하도록 하였습니다.

[CORE-39]: https://mcrs.atlassian.net/browse/CORE-39?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ