### PR TITLE
CORE-77 delete empty room and roomusers

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -445,3 +445,5 @@ _ReSharper*/
 _TeamCity*
 
 # DotCover is a Code Coverage 
+
+*.patch

--- a/app/api/v1/endpoints/room.py
+++ b/app/api/v1/endpoints/room.py
@@ -73,6 +73,7 @@ async def get_available_rooms(
     current_user: User = Depends(get_current_user),  # noqa : ARG001
     room_service: RoomService = Depends(get_room_service),
 ):
+    await room_service.cleanup_rooms()
     return await room_service.get_available_rooms()
 
 

--- a/app/api/v1/endpoints/watch.py
+++ b/app/api/v1/endpoints/watch.py
@@ -1,8 +1,10 @@
-from fastapi import APIRouter, status
+from fastapi import APIRouter, Depends, status
 from httpx import AsyncClient
 
 from app.core.config import settings
+from app.dependencies.services import get_room_service
 from app.schemas.watch import WatchGame, WatchGameUser
+from app.services.room_service import RoomService
 
 router = APIRouter()
 
@@ -12,7 +14,10 @@ router = APIRouter()
     response_model=list[WatchGame],
     status_code=status.HTTP_200_OK,
 )
-async def get_available_watch_games():
+async def get_available_watch_games(
+    room_service: RoomService = Depends(get_room_service),
+) -> list[WatchGame]:
+    await room_service.cleanup_rooms()
     async with AsyncClient() as client:
         response = await client.get(
             f"{settings.GAME_SERVER_URL}/api/v1/games/watch",

--- a/tests/api/test_room.py
+++ b/tests/api/test_room.py
@@ -228,6 +228,7 @@ async def test_get_available_rooms_success(login_client, mock_user):
     assert data[1]["current_users"] == 1
     assert data[1]["host_nickname"] == "AnotherHost"
     assert len(data[1]["users"]) == 1
+    mocks["services"]["room_service"].cleanup_rooms.assert_called_once()
     mocks["services"]["room_service"].get_available_rooms.assert_called_once()
 
 


### PR DESCRIPTION
[![CORE-77](https://badgen.net/badge/JIRA/CORE-77/0052CC)](https://mcrs.atlassian.net/browse/CORE-77) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=MCRMasters&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

유령방 없애는 숙원사업

cleanup function만들어서

서버 시작종료시 그리고 유저의 room / watch list request api 호출시 cleaup 먼저 실행하도록했습니다

[CORE-77]: https://mcrs.atlassian.net/browse/CORE-77?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ